### PR TITLE
Add location-aware estimate CTA

### DIFF
--- a/src/app/roof-replacement-cost/[slug]/page.tsx
+++ b/src/app/roof-replacement-cost/[slug]/page.tsx
@@ -119,7 +119,7 @@ export default async function Page({
             </section>
 
             <FAQ locationName={location.name} />
-            <GetEstimate />
+            <GetEstimate location={location.name} />
         </div>
     );
 }

--- a/src/app/roof-replacement/[slug]/page.tsx
+++ b/src/app/roof-replacement/[slug]/page.tsx
@@ -153,7 +153,7 @@ export default async function page({
             <FAQ locationName={location.name} />
 
             {/* CTA */}
-            <GetEstimate />
+            <GetEstimate location={location.name} />
         </div>
     );
 }

--- a/src/app/roofing-contractor/[slug]/page.tsx
+++ b/src/app/roofing-contractor/[slug]/page.tsx
@@ -155,7 +155,7 @@ Experience what makes Paragon Exterior the select roofing contractor of ${locati
 
             <FAQ locationName={location.name} />
             {/* CTA */}
-            <GetEstimate />
+            <GetEstimate location={location.name} />
         </div>
     );
 }

--- a/src/app/service-area/[slug]/page.tsx
+++ b/src/app/service-area/[slug]/page.tsx
@@ -150,7 +150,7 @@ When you spot a drip or after a storm, you want fast, reliable roof repair—and
             {/* FAQ */}
             <FAQ locationName={location.name}/>
             {/* CTA */}
-            <GetEstimate />
+            <GetEstimate location={location.name} />
         </div>
     );
 }

--- a/src/components/landing-ui/GetEstimate.tsx
+++ b/src/components/landing-ui/GetEstimate.tsx
@@ -1,16 +1,19 @@
 import HeaderText from "../HeaderText";
 import SecondaryText from "../SecondaryText";
 
-export default function GetEstimate() {
+export default function GetEstimate({ location }: { location?: string } = {}) {
+    const heading = location ? `Get Your Free Estimate in ${location}` : 'Get Your Free Estimate Today';
+    const subText = location
+        ? `We’re ready to help homeowners in ${location} with a personalized, no-obligation estimate. Find out why locals trust Paragon Exterior for roofing and siding.`
+        : `We’re here to understand your needs and provide a personalized, no-obligation estimate – because we treat your home like it’s our own. Find out why homeowners trust Paragon Exterior as thier trusted roofing and siding contractor.`;
+
     return (
         <div className="">
             <div className="px-6 sm:px-6 sm:py-32 lg:px-8">
                 <div className="mx-auto max-w-5xl text-center">
-                    <HeaderText variant="large">
-                        Get Your Free Estimate Today
-                    </HeaderText>
+                    <HeaderText variant="large">{heading}</HeaderText>
                     <SecondaryText className="font-secondary mx-auto mt-6 max-w-xl text-gray-600">
-                        We’re here to understand your needs and provide a personalized, no-obligation estimate – because we treat your home like it’s our own. Find out why homeowners trust Paragon Exterior as thier trusted roofing and siding contractor.
+                        {subText}
                     </SecondaryText>
                     <div className="mt-10 flex items-center justify-center gap-x-6">
                         <a
@@ -24,5 +27,5 @@ export default function GetEstimate() {
                 </div>
             </div>
         </div>
-    )
+    );
 }


### PR DESCRIPTION
## Summary
- tweak GetEstimate component to accept an optional `location`
- pass the location slug to the CTA on service-area, roofing-contractor, roof replacement, and cost pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c406bba3083218f5410d42e3bfbef