### PR TITLE
Add roofing service pages

### DIFF
--- a/src/app/services/emergency-roof-repair/page.tsx
+++ b/src/app/services/emergency-roof-repair/page.tsx
@@ -1,0 +1,49 @@
+import GetEstimate from '@/components/landing-ui/GetEstimate'
+import Hero from '@/components/service-page/Hero'
+import HeaderText from '@/components/HeaderText'
+import SecondaryText from '@/components/SecondaryText'
+import React from 'react'
+
+export const metadata = {
+  title: 'Emergency Roof Repair | Paragon Exterior',
+  description: 'Call Paragon Exterior for fast emergency roof repair. We secure storm-damaged roofs and protect your home when minutes count.'
+}
+
+export default function Page() {
+  return (
+    <div className='min-h-screen'>
+      <Hero
+        mainText={`Emergency Roof Repair`}
+        subText="Storm damage? We respond quickly to stabilize your roof and prevent further harm."
+        imgSrc="/images/roof-service/emergency-roofing/roof-damage.jpg"
+        imgAlt="Emergency roof repair by Paragon Exterior"
+      />
+
+      <section className='py-24'>
+        <div className='mx-auto w-5/6 px-6 lg:px-8'>
+          <HeaderText as='h2' className='text-primaryblue'>When to Call for <span className='text-amber-500'>Emergency Service</span></HeaderText>
+          <SecondaryText as='p'>After severe storms or sudden leaks, immediate action can save thousands in repairs.</SecondaryText>
+          <ul className='mt-8 list-disc space-y-2 pl-5 text-gray-700'>
+            <li>Tree or wind damage to your roof</li>
+            <li>Water pouring into the attic or living space</li>
+            <li>Loose shingles exposing the decking</li>
+          </ul>
+        </div>
+      </section>
+
+      <section className='bg-gray-50 py-24'>
+        <div className='mx-auto w-5/6 px-6 lg:px-8'>
+          <HeaderText as='h2' className='text-primaryblue'>Our Rapid Response Plan</HeaderText>
+          <SecondaryText as='p'>We arrive ready to secure your home and start the roof repair process right away.</SecondaryText>
+          <ol className='mt-8 list-decimal space-y-2 pl-5 text-gray-700'>
+            <li>Temporary tarping and structural stabilization</li>
+            <li>Detailed inspection of storm damage</li>
+            <li>Fast, permanent repairs to restore protection</li>
+          </ol>
+        </div>
+      </section>
+
+      <GetEstimate />
+    </div>
+  )
+}

--- a/src/app/services/flat-roofing/page.tsx
+++ b/src/app/services/flat-roofing/page.tsx
@@ -1,0 +1,49 @@
+import GetEstimate from '@/components/landing-ui/GetEstimate'
+import Hero from '@/components/service-page/Hero'
+import HeaderText from '@/components/HeaderText'
+import SecondaryText from '@/components/SecondaryText'
+import React from 'react'
+
+export const metadata = {
+  title: 'Flat Roofing | Paragon Exterior',
+  description: 'Specialized flat roofing solutions for homes and businesses. Paragon Exterior installs durable membranes and performs flat roof repair.'
+}
+
+export default function Page() {
+  return (
+    <div className='min-h-screen'>
+      <Hero
+        mainText={`Flat Roofing`}
+        subText="Need a dependable flat roof? Our team installs and maintains low-slope systems designed to last."
+        imgSrc="/images/roof-service/flat-roofing/flat-roof.jpg"
+        imgAlt="Flat roofing installation by Paragon Exterior"
+      />
+
+      <section className='py-24'>
+        <div className='mx-auto w-5/6 px-6 lg:px-8'>
+          <HeaderText as='h2' className='text-primaryblue'>Why <span className='text-amber-500'>Flat Roofing</span>?</HeaderText>
+          <SecondaryText as='p'>Flat roofs offer sleek looks and usable space, but they require the right materials to prevent ponding water and leaks.</SecondaryText>
+          <ul className='mt-8 list-disc space-y-2 pl-5 text-gray-700'>
+            <li>Energy-efficient membranes</li>
+            <li>Versatile design for additions and decks</li>
+            <li>Professional maintenance and repair services</li>
+          </ul>
+        </div>
+      </section>
+
+      <section className='bg-gray-50 py-24'>
+        <div className='mx-auto w-5/6 px-6 lg:px-8'>
+          <HeaderText as='h2' className='text-primaryblue'>Our Materials and Expertise</HeaderText>
+          <SecondaryText as='p'>We install high-quality single-ply membranes and coatings that withstand harsh weather and foot traffic.</SecondaryText>
+          <ol className='mt-8 list-decimal space-y-2 pl-5 text-gray-700'>
+            <li>Comprehensive roof inspection</li>
+            <li>Custom-tailored installation plan</li>
+            <li>Ongoing support for flat roof repair</li>
+          </ol>
+        </div>
+      </section>
+
+      <GetEstimate />
+    </div>
+  )
+}

--- a/src/app/services/roof-leak-repair/page.tsx
+++ b/src/app/services/roof-leak-repair/page.tsx
@@ -1,0 +1,49 @@
+import GetEstimate from '@/components/landing-ui/GetEstimate'
+import Hero from '@/components/service-page/Hero'
+import HeaderText from '@/components/HeaderText'
+import SecondaryText from '@/components/SecondaryText'
+import React from 'react'
+
+export const metadata = {
+  title: 'Roof Leak Repair | Paragon Exterior',
+  description: 'Stop roof leaks fast with Paragon Exterior. We provide thorough leak detection and effective roof leak repair services.'
+}
+
+export default function Page() {
+  return (
+    <div className='min-h-screen'>
+      <Hero
+        mainText={`Roof Leak Repair`}
+        subText="When a leak appears, our certified roofers find the source and fix it for good."
+        imgSrc="/images/roof-service/roof-leak/roof-leak.jpg"
+        imgAlt="Roof leak repair by Paragon Exterior"
+      />
+
+      <section className='py-24'>
+        <div className='mx-auto w-5/6 px-6 lg:px-8'>
+          <HeaderText as='h2' className='text-primaryblue'>Signs You Need <span className='text-amber-500'>Leak Repair</span></HeaderText>
+          <SecondaryText as='p'>Ignoring a small drip can lead to costly structural damage. Watch for these common warning signs.</SecondaryText>
+          <ul className='mt-8 list-disc space-y-2 pl-5 text-gray-700'>
+            <li>Water stains on ceilings or walls</li>
+            <li>Missing or cracked shingles</li>
+            <li>Mold or mildew smells in the attic</li>
+          </ul>
+        </div>
+      </section>
+
+      <section className='bg-gray-50 py-24'>
+        <div className='mx-auto w-5/6 px-6 lg:px-8'>
+          <HeaderText as='h2' className='text-primaryblue'>How We Fix Leaks</HeaderText>
+          <SecondaryText as='p'>Our crew pinpoints the entry point, repairs damaged materials, and ensures your roof is watertight again.</SecondaryText>
+          <ol className='mt-8 list-decimal space-y-2 pl-5 text-gray-700'>
+            <li>Comprehensive roof inspection</li>
+            <li>Targeted repair of flashing and shingles</li>
+            <li>Final evaluation to confirm the leak is gone</li>
+          </ol>
+        </div>
+      </section>
+
+      <GetEstimate />
+    </div>
+  )
+}

--- a/src/app/services/roof-replacement/page.tsx
+++ b/src/app/services/roof-replacement/page.tsx
@@ -1,0 +1,49 @@
+import GetEstimate from '@/components/landing-ui/GetEstimate'
+import Hero from '@/components/service-page/Hero'
+import HeaderText from '@/components/HeaderText'
+import SecondaryText from '@/components/SecondaryText'
+import React from 'react'
+
+export const metadata = {
+  title: 'Roof Replacement | Paragon Exterior',
+  description: 'Professional roof replacement services for long-lasting protection. Trust Paragon Exterior for expert installation and durable materials.'
+}
+
+export default function Page() {
+  return (
+    <div className='min-h-screen'>
+      <Hero
+        mainText={`Roof Replacement`}
+        subText="Rely on our experienced roofers for complete roof replacement, from tear-off to final inspection. We install durable systems that stand up to the elements."
+        imgSrc="/images/roof-service/roof-replacement/roof-replacement.avif"
+        imgAlt="Roof replacement project by Paragon Exterior"
+      />
+
+      <section className='py-24'>
+        <div className='mx-auto w-5/6 px-6 lg:px-8'>
+          <HeaderText as='h2' className='text-primaryblue'>Why <span className='text-amber-500'>Choose</span> Us</HeaderText>
+          <SecondaryText as='p'>Our licensed team focuses on quality craftsmanship and honest service. From roof installation to cleanup, we handle every detail so you can enjoy years of worry-free protection.</SecondaryText>
+          <ul className='mt-8 list-disc space-y-2 pl-5 text-gray-700'>
+            <li>High-performance shingles and metal options</li>
+            <li>Clear pricing and industry-leading warranties</li>
+            <li>Respectful crews who treat your property like their own</li>
+          </ul>
+        </div>
+      </section>
+
+      <section className='bg-gray-50 py-24'>
+        <div className='mx-auto w-5/6 px-6 lg:px-8'>
+          <HeaderText as='h2' className='text-primaryblue'>Our Roof Replacement Process</HeaderText>
+          <SecondaryText as='p'>We make roof replacement simple. Here’s how we ensure a smooth project from start to finish.</SecondaryText>
+          <ol className='mt-8 list-decimal space-y-2 pl-5 text-gray-700'>
+            <li>Free inspection and written estimate</li>
+            <li>Old roof removal and decking assessment</li>
+            <li>Precise installation and thorough cleanup</li>
+          </ol>
+        </div>
+      </section>
+
+      <GetEstimate />
+    </div>
+  )
+}

--- a/src/app/services/skylight-installation/page.tsx
+++ b/src/app/services/skylight-installation/page.tsx
@@ -1,0 +1,49 @@
+import GetEstimate from '@/components/landing-ui/GetEstimate'
+import Hero from '@/components/service-page/Hero'
+import HeaderText from '@/components/HeaderText'
+import SecondaryText from '@/components/SecondaryText'
+import React from 'react'
+
+export const metadata = {
+  title: 'Skylight Installation | Paragon Exterior',
+  description: 'Brighten your home with professional skylight installation. Paragon Exterior installs leak-free skylights for natural light and energy savings.'
+}
+
+export default function Page() {
+  return (
+    <div className='min-h-screen'>
+      <Hero
+        mainText={`Skylight Installation`}
+        subText="Let our roofing experts add beautiful natural light with skylight installation that’s sealed and secure."
+        imgSrc="/images/roof-service/skylight/skylight.jpg"
+        imgAlt="Skylight installed by Paragon Exterior"
+      />
+
+      <section className='py-24'>
+        <div className='mx-auto w-5/6 px-6 lg:px-8'>
+          <HeaderText as='h2' className='text-primaryblue'>Benefits of <span className='text-amber-500'>Skylights</span></HeaderText>
+          <SecondaryText as='p'>Skylights flood your home with daylight, reduce dependence on artificial lighting, and make rooms feel larger and more inviting.</SecondaryText>
+          <ul className='mt-8 list-disc space-y-2 pl-5 text-gray-700'>
+            <li>Enhanced natural lighting</li>
+            <li>Improved ventilation options</li>
+            <li>Energy savings from passive solar warmth</li>
+          </ul>
+        </div>
+      </section>
+
+      <section className='bg-gray-50 py-24'>
+        <div className='mx-auto w-5/6 px-6 lg:px-8'>
+          <HeaderText as='h2' className='text-primaryblue'>Our Installation Approach</HeaderText>
+          <SecondaryText as='p'>We ensure every skylight is properly flashed and insulated to prevent leaks and drafts.</SecondaryText>
+          <ol className='mt-8 list-decimal space-y-2 pl-5 text-gray-700'>
+            <li>Selection of the right skylight style</li>
+            <li>Professional placement and framing</li>
+            <li>Waterproof sealing and final inspection</li>
+          </ol>
+        </div>
+      </section>
+
+      <GetEstimate />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add full service pages for roof replacement, skylight installation, flat roofing, roof leak repair, and emergency roof repair
- use Hero and GetEstimate components across new pages
- include two extra informational sections on each page with amber highlight text and primaryblue CTAs

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eee7b077483218abeaadb7ea43f54