### PR TITLE
Add dedicated window type pages

### DIFF
--- a/src/app/windows/awning/page.tsx
+++ b/src/app/windows/awning/page.tsx
@@ -1,0 +1,63 @@
+import type {Metadata} from 'next';
+import Hero from '@/components/service-page/Hero';
+import InfoSection from '@/components/service-page/Info';
+import Row from '@/components/Row';
+import GetEstimate from '@/components/landing-ui/GetEstimate';
+import {WhyParagonAwningWindows} from '@/components/WhyParagon';
+
+export const metadata: Metadata = {
+    title: 'Awning Windows | Professional Awning Window Installation',
+    description: 'Awning windows hinge at the top to protect your home from rain while ventilating. Our awning windows provide privacy and energy efficiency. Durable awning windows suit basements and bathrooms. Paragon Exterior installs professional awning windows across PA, NJ, and DE.',
+    openGraph: {
+        title: 'Awning Windows | Professional Awning Window Installation',
+        description: 'Awning windows hinge at the top to protect your home from rain while ventilating. Our awning windows provide privacy and energy efficiency. Durable awning windows suit basements and bathrooms. Paragon Exterior installs professional awning windows across PA, NJ, and DE.',
+        type: 'website',
+        images: ['/images/windows/awning/awning-hero.webp'],
+    },
+};
+
+export default function AwningWindowsPage() {
+    return (
+        <div className="min-h-screen">
+            <Hero
+                mainText="Awning Windows"
+                subText="Top-hinged awning windows offer privacy and protection from light rain while still allowing ventilation. Paragon Exterior installs awning windows for homeowners in Pennsylvania, New Jersey, and Delaware with expert craftsmanship."
+                imgSrc="/images/windows/awning/awning-hero.webp"
+                imgAlt="Professional awning window installation by Paragon Exterior"
+            />
+            <InfoSection
+                imgSrc="/images/windows/awning/awning-1.webp"
+                imgAlt="Awning windows professionally installed on home"
+                titleAs="h1"
+                title="Awning Windows for Your Home"
+                mainContent="Awning windows are hinged at the top and open outward from the bottom, creating a protective awning when open. This design lets you enjoy fresh air even during light rain showers. Awning windows are commonly used in bathrooms, basements, and other areas requiring privacy yet good ventilation. The tight compression seal also boosts energy efficiency."
+                bottomContent="Paragon Exterior has installed countless awning windows throughout the Greater Philadelphia area. Our team understands the unique hardware and framing considerations that keep awning windows operating smoothly for years."
+                imagePosition="right"
+            />
+            <Row
+                title="Key Benefits of Awning Windows"
+                description="Because they shed rainwater away from your home, awning windows can stay open in wet weather. They also provide excellent privacy and complement spaces where ventilation is needed high on the wall."
+                imageSrc="/images/windows/awning/awning-2.webp"
+            />
+            <Row
+                title="Ideal Applications for Awning Windows"
+                description="Awning windows excel in bathrooms, basements, and first-floor rooms where you want airflow without sacrificing privacy. They're also great companions to larger stationary windows."
+                imageSrc="/images/windows/awning/awning-3.webp"
+                reverse
+                className="pt-12 lg:pt-24"
+            />
+            <Row
+                title="Professional Awning Window Installation"
+                description="Top-hinged windows require precise alignment and durable hardware to prevent sagging or leaks. Our installers secure every hinge and seal to ensure worry-free performance season after season."
+                imageSrc="/images/windows/awning/awning-4.webp"
+            />
+            <WhyParagonAwningWindows
+                title="Why Choose Paragon Exterior for Awning Windows?"
+                titleAs="h2"
+            />
+            <div className="py-12">
+                <GetEstimate />
+            </div>
+        </div>
+    );
+}

--- a/src/app/windows/bay/page.tsx
+++ b/src/app/windows/bay/page.tsx
@@ -1,0 +1,63 @@
+import type {Metadata} from 'next';
+import Hero from '@/components/service-page/Hero';
+import InfoSection from '@/components/service-page/Info';
+import Row from '@/components/Row';
+import GetEstimate from '@/components/landing-ui/GetEstimate';
+import {WhyParagonBayWindows} from '@/components/WhyParagon';
+
+export const metadata: Metadata = {
+    title: 'Bay Windows | Professional Bay Window Installation',
+    description: 'Bay windows project outward to add space and panoramic views. Our bay windows fill rooms with natural light and create cozy nooks. Energy-efficient bay windows boost curb appeal. Paragon Exterior installs professional bay windows throughout PA, NJ, and DE.',
+    openGraph: {
+        title: 'Bay Windows | Professional Bay Window Installation',
+        description: 'Bay windows project outward to add space and panoramic views. Our bay windows fill rooms with natural light and create cozy nooks. Energy-efficient bay windows boost curb appeal. Paragon Exterior installs professional bay windows throughout PA, NJ, and DE.',
+        type: 'website',
+        images: ['/images/windows/bay/bay-hero.webp'],
+    },
+};
+
+export default function BayWindowsPage() {
+    return (
+        <div className="min-h-screen">
+            <Hero
+                mainText="Bay Windows"
+                subText="Bay windows project outward to create cozy nooks and expansive views. Paragon Exterior designs and installs bay windows for homeowners across Pennsylvania, New Jersey, and Delaware."
+                imgSrc="/images/windows/bay/bay-hero.webp"
+                imgAlt="Professional bay window installation by Paragon Exterior"
+            />
+            <InfoSection
+                imgSrc="/images/windows/bay/bay-1.webp"
+                imgAlt="Bay windows professionally installed on home"
+                titleAs="h1"
+                title="Bay Windows for Your Home"
+                mainContent="A bay window combines multiple window panels that extend beyond the exterior wall, increasing interior space and flooding rooms with natural light. Angled sections capture panoramic views and add striking architectural detail to any home."
+                bottomContent="Paragon Exterior's experienced team constructs bay windows with proper support and weatherproofing. We serve the entire Greater Philadelphia region, delivering custom designs that enhance both aesthetics and functionality."
+                imagePosition="right"
+            />
+            <Row
+                title="Benefits of Bay Windows"
+                description="Bay windows make rooms feel larger while providing excellent daylight and extended views. They create charming alcoves perfect for seating or displays."
+                imageSrc="/images/windows/bay/bay-2.webp"
+            />
+            <Row
+                title="Where Bay Windows Work Best"
+                description="Install bay windows in living rooms, breakfast areas, or any space that can benefit from extra light and dimension. They're popular in both traditional and contemporary homes."
+                imageSrc="/images/windows/bay/bay-3.webp"
+                reverse
+                className="pt-12 lg:pt-24"
+            />
+            <Row
+                title="Professional Bay Window Installation"
+                description="Because bay windows project outward, correct structural support and flashing are essential. Our installers coordinate every detail to ensure a tight, weather-resistant fit."
+                imageSrc="/images/windows/bay/bay-4.webp"
+            />
+            <WhyParagonBayWindows
+                title="Why Choose Paragon Exterior for Bay Windows?"
+                titleAs="h2"
+            />
+            <div className="py-12">
+                <GetEstimate />
+            </div>
+        </div>
+    );
+}

--- a/src/app/windows/bow/page.tsx
+++ b/src/app/windows/bow/page.tsx
@@ -1,0 +1,63 @@
+import type {Metadata} from 'next';
+import Hero from '@/components/service-page/Hero';
+import InfoSection from '@/components/service-page/Info';
+import Row from '@/components/Row';
+import GetEstimate from '@/components/landing-ui/GetEstimate';
+import {WhyParagonBowWindows} from '@/components/WhyParagon';
+
+export const metadata: Metadata = {
+    title: 'Bow Windows | Professional Bow Window Installation',
+    description: 'Bow windows form a gentle curve for elegant design and sweeping views. Our bow windows expand interior space and brighten your home. Energy-efficient bow windows enhance architectural style. Trust Paragon Exterior for professional bow windows in PA, NJ, and DE.',
+    openGraph: {
+        title: 'Bow Windows | Professional Bow Window Installation',
+        description: 'Bow windows form a gentle curve for elegant design and sweeping views. Our bow windows expand interior space and brighten your home. Energy-efficient bow windows enhance architectural style. Trust Paragon Exterior for professional bow windows in PA, NJ, and DE.',
+        type: 'website',
+        images: ['/images/windows/bow/bow-hero.webp'],
+    },
+};
+
+export default function BowWindowsPage() {
+    return (
+        <div className="min-h-screen">
+            <Hero
+                mainText="Bow Windows"
+                subText="Bow windows offer a graceful, curved projection for panoramic views. Paragon Exterior crafts bow window installations for homes across Pennsylvania, New Jersey, and Delaware."
+                imgSrc="/images/windows/bow/bow-hero.webp"
+                imgAlt="Professional bow window installation by Paragon Exterior"
+            />
+            <InfoSection
+                imgSrc="/images/windows/bow/bow-1.webp"
+                imgAlt="Bow windows professionally installed on home"
+                titleAs="h1"
+                title="Bow Windows for Your Home"
+                mainContent="Bow windows consist of four or more casement units joined to form a gentle curve. This design maximizes view area and creates an elegant exterior appearance. Bow windows can dramatically enhance curb appeal and provide extra interior space."
+                bottomContent="We have the structural expertise needed for complex bow window installations throughout the Greater Philadelphia area. Paragon Exterior ensures each unit aligns perfectly for smooth operation and long-term durability."
+                imagePosition="right"
+            />
+            <Row
+                title="Advantages of Bow Windows"
+                description="The continuous curve of a bow window softens exterior lines while expanding interior space. Multiple panels allow a sweeping view that draws in abundant light."
+                imageSrc="/images/windows/bow/bow-2.webp"
+            />
+            <Row
+                title="Ideal Locations for Bow Windows"
+                description="Bow windows make a statement in living and dining rooms or any facade where you desire a graceful architectural element. They're especially popular on Victorian and upscale homes."
+                imageSrc="/images/windows/bow/bow-3.webp"
+                reverse
+                className="pt-12 lg:pt-24"
+            />
+            <Row
+                title="Professional Bow Window Installation"
+                description="Bow installations are complex and require precise engineering. Our professionals handle framing, support cables, and waterproofing so your bow windows remain secure and beautiful."
+                imageSrc="/images/windows/bow/bow-4.webp"
+            />
+            <WhyParagonBowWindows
+                title="Why Choose Paragon Exterior for Bow Windows?"
+                titleAs="h2"
+            />
+            <div className="py-12">
+                <GetEstimate />
+            </div>
+        </div>
+    );
+}

--- a/src/app/windows/casement/page.tsx
+++ b/src/app/windows/casement/page.tsx
@@ -1,0 +1,63 @@
+import type {Metadata} from 'next';
+import Hero from '@/components/service-page/Hero';
+import InfoSection from '@/components/service-page/Info';
+import Row from '@/components/Row';
+import GetEstimate from '@/components/landing-ui/GetEstimate';
+import {WhyParagonCasementWindows} from '@/components/WhyParagon';
+
+export const metadata: Metadata = {
+    title: 'Casement Windows | Professional Casement Window Installation',
+    description: 'Casement windows deliver excellent ventilation and unobstructed views. Our casement windows swing open for full airflow and easy cleaning. Energy-efficient casement windows keep drafts out. Choose Paragon Exterior for professional casement windows in PA, NJ, and DE.',
+    openGraph: {
+        title: 'Casement Windows | Professional Casement Window Installation',
+        description: 'Casement windows deliver excellent ventilation and unobstructed views. Our casement windows swing open for full airflow and easy cleaning. Energy-efficient casement windows keep drafts out. Choose Paragon Exterior for professional casement windows in PA, NJ, and DE.',
+        type: 'website',
+        images: ['/images/windows/casement/casement-hero.webp'],
+    },
+};
+
+export default function CasementWindowsPage() {
+    return (
+        <div className="min-h-screen">
+            <Hero
+                mainText="Casement Windows"
+                subText="Side-hinged casement windows open fully for refreshing breezes and crystal-clear views. Paragon Exterior installs casement windows across Pennsylvania, New Jersey, and Delaware with precision and energy-efficient craftsmanship."
+                imgSrc="/images/windows/casement/casement-hero.webp"
+                imgAlt="Professional casement window installation by Paragon Exterior"
+            />
+            <InfoSection
+                imgSrc="/images/windows/casement/casement-1.webp"
+                imgAlt="Casement windows professionally installed on home"
+                titleAs="h1"
+                title="Casement Windows for Your Home"
+                mainContent="Casement windows operate on sturdy side hinges, allowing the sash to swing outward for maximum airflow and easy cleaning. Because the entire window opens, casement windows capture breezes like a sail to quickly ventilate your home. When closed, the sash presses firmly against the frame, providing a tight weather-resistant seal that enhances energy efficiency. Contemporary design options make casement windows a versatile choice for any room."
+                bottomContent="Paragon Exterior specializes in casement window installation throughout Pennsylvania, New Jersey, and Delaware. Our team ensures a precise fit and smooth crank operation so your new casement windows deliver lasting performance in the Greater Philadelphia area."
+                imagePosition="right"
+            />
+            <Row
+                title="Benefits of Casement Windows"
+                description="A full 90-degree opening maximizes ventilation and allows for unobstructed views. The crank handle makes cleaning simple from inside your home while the compression seal keeps drafts out and boosts efficiency."
+                imageSrc="/images/windows/casement/casement-2.webp"
+            />
+            <Row
+                title="Where Casement Windows Shine"
+                description="Casement windows are ideal in kitchens, over sinks, or anywhere you want clear sightlines and excellent ventilation. They work well in modern designs but complement many architectural styles throughout PA, NJ, and DE."
+                imageSrc="/images/windows/casement/casement-3.webp"
+                reverse
+                className="pt-12 lg:pt-24"
+            />
+            <Row
+                title="Professional Casement Window Installation"
+                description="Proper installation ensures the hardware operates smoothly and the window seals tightly against the elements. Our experts level each frame, adjust the hinges, and verify weatherstripping so your casement windows perform flawlessly."
+                imageSrc="/images/windows/casement/casement-4.webp"
+            />
+            <WhyParagonCasementWindows
+                title="Why Choose Paragon Exterior for Casement Windows?"
+                titleAs="h2"
+            />
+            <div className="py-12">
+                <GetEstimate />
+            </div>
+        </div>
+    );
+}

--- a/src/app/windows/double-hung/page.tsx
+++ b/src/app/windows/double-hung/page.tsx
@@ -1,0 +1,63 @@
+import type {Metadata} from 'next';
+import Hero from '@/components/service-page/Hero';
+import InfoSection from '@/components/service-page/Info';
+import Row from '@/components/Row';
+import GetEstimate from '@/components/landing-ui/GetEstimate';
+import {WhyParagonDoubleHungWindows} from '@/components/WhyParagon';
+
+export const metadata: Metadata = {
+    title: 'Double Hung Windows | Professional Double Hung Window Installation',
+    description: 'Double hung windows offer timeless style with top and bottom sash operation. Our double hung windows provide versatile ventilation and easy cleaning. Energy-efficient double hung windows fit any architectural style. Trust Paragon Exterior for professional double hung windows in PA, NJ, and DE.',
+    openGraph: {
+        title: 'Double Hung Windows | Professional Double Hung Window Installation',
+        description: 'Double hung windows offer timeless style with top and bottom sash operation. Our double hung windows provide versatile ventilation and easy cleaning. Energy-efficient double hung windows fit any architectural style. Trust Paragon Exterior for professional double hung windows in PA, NJ, and DE.',
+        type: 'website',
+        images: ['/images/windows/double-hung/double-hung-hero.webp'],
+    },
+};
+
+export default function DoubleHungWindowsPage() {
+    return (
+        <div className="min-h-screen">
+            <Hero
+                mainText="Double Hung Windows"
+                subText="Double hung windows provide classic appeal and flexible airflow with two operable sashes. Paragon Exterior installs double hung windows across Pennsylvania, New Jersey, and Delaware with expert craftsmanship."
+                imgSrc="/images/windows/double-hung/double-hung-hero.webp"
+                imgAlt="Professional double hung window installation by Paragon Exterior"
+            />
+            <InfoSection
+                imgSrc="/images/windows/double-hung/double-hung-1.webp"
+                imgAlt="Double hung windows professionally installed on home"
+                titleAs="h1"
+                title="Double Hung Windows for Your Home"
+                mainContent="Double hung windows feature both upper and lower sashes that slide vertically, offering flexible ventilation options. Open the top sash to release warm air or the bottom sash for fresh breezes. Modern balances and tilt-in designs make cleaning easy from inside your home. Their classic appearance suits almost any architectural style."
+                bottomContent="Our team has extensive experience installing double hung windows in homes across the Greater Philadelphia region. We ensure smooth sash movement, proper weatherstripping, and secure locks so your new double hung windows provide lasting comfort and energy efficiency."
+                imagePosition="right"
+            />
+            <Row
+                title="Advantages of Double Hung Windows"
+                description="Two operable sashes give you precise control over airflow. Tilt-in features simplify cleaning while maintaining the traditional look many homeowners love. Double hung windows also accommodate window AC units when needed."
+                imageSrc="/images/windows/double-hung/double-hung-2.webp"
+            />
+            <Row
+                title="Best Places for Double Hung Windows"
+                description="These versatile windows complement historic homes and modern builds alike. They work especially well in bedrooms and living spaces where controllable ventilation is a priority."
+                imageSrc="/images/windows/double-hung/double-hung-3.webp"
+                reverse
+                className="pt-12 lg:pt-24"
+            />
+            <Row
+                title="Professional Double Hung Window Installation"
+                description="Correct installation is key to preventing air leakage and keeping both sashes operating smoothly. Paragon Exterior’s technicians align balances, install durable hardware, and seal every edge for optimal performance."
+                imageSrc="/images/windows/double-hung/double-hung-4.webp"
+            />
+            <WhyParagonDoubleHungWindows
+                title="Why Choose Paragon Exterior for Double Hung Windows?"
+                titleAs="h2"
+            />
+            <div className="py-12">
+                <GetEstimate />
+            </div>
+        </div>
+    );
+}

--- a/src/app/windows/glider/page.tsx
+++ b/src/app/windows/glider/page.tsx
@@ -1,0 +1,63 @@
+import type {Metadata} from 'next';
+import Hero from '@/components/service-page/Hero';
+import InfoSection from '@/components/service-page/Info';
+import Row from '@/components/Row';
+import GetEstimate from '@/components/landing-ui/GetEstimate';
+import {WhyParagonGliderWindows} from '@/components/WhyParagon';
+
+export const metadata: Metadata = {
+    title: 'Glider Windows | Professional Glider Window Installation',
+    description: 'Glider windows slide horizontally for a modern look and effortless use. Our glider windows require no exterior clearance and create wide openings. Energy-efficient glider windows are perfect near patios. Choose Paragon Exterior for professional glider windows in PA, NJ, and DE.',
+    openGraph: {
+        title: 'Glider Windows | Professional Glider Window Installation',
+        description: 'Glider windows slide horizontally for a modern look and effortless use. Our glider windows require no exterior clearance and create wide openings. Energy-efficient glider windows are perfect near patios. Choose Paragon Exterior for professional glider windows in PA, NJ, and DE.',
+        type: 'website',
+        images: ['/images/windows/glider/glider-hero.webp'],
+    },
+};
+
+export default function GliderWindowsPage() {
+    return (
+        <div className="min-h-screen">
+            <Hero
+                mainText="Glider Windows"
+                subText="Glider windows slide horizontally for a sleek, modern look and easy operation. Paragon Exterior provides glider window installation throughout Pennsylvania, New Jersey, and Delaware."
+                imgSrc="/images/windows/glider/glider-hero.webp"
+                imgAlt="Professional glider window installation by Paragon Exterior"
+            />
+            <InfoSection
+                imgSrc="/images/windows/glider/glider-1.webp"
+                imgAlt="Glider windows professionally installed on home"
+                titleAs="h1"
+                title="Glider Windows for Your Home"
+                mainContent="Glider windows operate on horizontal tracks, making them ideal where exterior clearance is limited. Their streamlined design offers wide glass areas for plentiful natural light. With minimal moving parts, gliders are simple to use and provide a contemporary aesthetic."
+                bottomContent="Serving the Greater Philadelphia area, Paragon Exterior installs glider windows with level tracks and smooth rollers. Our craftsmanship ensures effortless operation and long-lasting energy efficiency."
+                imagePosition="right"
+            />
+            <Row
+                title="Benefits of Glider Windows"
+                description="Glider windows don't require exterior swing space, so they're perfect near patios or walkways. Large openings bring in daylight while the sliding sash is easy to operate."
+                imageSrc="/images/windows/glider/glider-2.webp"
+            />
+            <Row
+                title="Best Uses for Glider Windows"
+                description="These windows shine in modern homes and spaces where you want uninterrupted views. They're often installed over kitchen counters or in contemporary living rooms across PA, NJ, and DE."
+                imageSrc="/images/windows/glider/glider-3.webp"
+                reverse
+                className="pt-12 lg:pt-24"
+            />
+            <Row
+                title="Professional Glider Window Installation"
+                description="Accurate track installation prevents sticking and drafts. We keep the sliding mechanism clean and secure so your glider windows glide smoothly for years."
+                imageSrc="/images/windows/glider/glider-4.webp"
+            />
+            <WhyParagonGliderWindows
+                title="Why Choose Paragon Exterior for Glider Windows?"
+                titleAs="h2"
+            />
+            <div className="py-12">
+                <GetEstimate />
+            </div>
+        </div>
+    );
+}

--- a/src/app/windows/picture/page.tsx
+++ b/src/app/windows/picture/page.tsx
@@ -1,0 +1,63 @@
+import type {Metadata} from 'next';
+import Hero from '@/components/service-page/Hero';
+import InfoSection from '@/components/service-page/Info';
+import Row from '@/components/Row';
+import GetEstimate from '@/components/landing-ui/GetEstimate';
+import {WhyParagonPictureWindows} from '@/components/WhyParagon';
+
+export const metadata: Metadata = {
+    title: 'Picture Windows | Professional Picture Window Installation',
+    description: 'Picture windows provide unobstructed views and excellent energy efficiency. Our picture windows let natural light flood in while reducing drafts. Low-maintenance picture windows maximize your scenery. Paragon Exterior installs professional picture windows in PA, NJ, and DE.',
+    openGraph: {
+        title: 'Picture Windows | Professional Picture Window Installation',
+        description: 'Picture windows provide unobstructed views and excellent energy efficiency. Our picture windows let natural light flood in while reducing drafts. Low-maintenance picture windows maximize your scenery. Paragon Exterior installs professional picture windows in PA, NJ, and DE.',
+        type: 'website',
+        images: ['/images/windows/picture/picture-hero.webp'],
+    },
+};
+
+export default function PictureWindowsPage() {
+    return (
+        <div className="min-h-screen">
+            <Hero
+                mainText="Picture Windows"
+                subText="Picture windows provide expansive, unobstructed views with superior energy efficiency. Paragon Exterior installs picture windows for homeowners across Pennsylvania, New Jersey, and Delaware."
+                imgSrc="/images/windows/picture/picture-hero.webp"
+                imgAlt="Professional picture window installation by Paragon Exterior"
+            />
+            <InfoSection
+                imgSrc="/images/windows/picture/picture-1.webp"
+                imgAlt="Picture windows professionally installed on home"
+                titleAs="h1"
+                title="Picture Windows for Your Home"
+                mainContent="Picture windows are fixed panes of glass that do not open, making them highly energy efficient and perfect for showcasing scenic views. With no moving parts, they require minimal maintenance and offer the lowest cost per square foot of glass."
+                bottomContent="Paragon Exterior specializes in installing picture windows of all sizes in the Greater Philadelphia area. We ensure airtight seals and expert framing so your new picture windows deliver maximum light and efficiency."
+                imagePosition="right"
+            />
+            <Row
+                title="Benefits of Picture Windows"
+                description="Because they are stationary, picture windows eliminate drafts and provide exceptional insulation. Large glass areas flood your home with natural light and let you enjoy the outside scenery."
+                imageSrc="/images/windows/picture/picture-2.webp"
+            />
+            <Row
+                title="Best Places for Picture Windows"
+                description="Install picture windows in living rooms, stairwells, or any space where ventilation isn't necessary but a view is desired. They're often paired with operable windows for airflow."
+                imageSrc="/images/windows/picture/picture-3.webp"
+                reverse
+                className="pt-12 lg:pt-24"
+            />
+            <Row
+                title="Professional Picture Window Installation"
+                description="Proper sealing and flashing are crucial for fixed windows. Our team secures every edge to prevent leaks and ensure your picture windows last for decades."
+                imageSrc="/images/windows/picture/picture-4.webp"
+            />
+            <WhyParagonPictureWindows
+                title="Why Choose Paragon Exterior for Picture Windows?"
+                titleAs="h2"
+            />
+            <div className="py-12">
+                <GetEstimate />
+            </div>
+        </div>
+    );
+}

--- a/src/app/windows/round-top/page.tsx
+++ b/src/app/windows/round-top/page.tsx
@@ -1,0 +1,63 @@
+import type {Metadata} from 'next';
+import Hero from '@/components/service-page/Hero';
+import InfoSection from '@/components/service-page/Info';
+import Row from '@/components/Row';
+import GetEstimate from '@/components/landing-ui/GetEstimate';
+import {WhyParagonRoundTopWindows} from '@/components/WhyParagon';
+
+export const metadata: Metadata = {
+    title: 'Round Top Windows | Professional Round Top Window Installation',
+    description: 'Round top windows add distinctive arches and architectural interest. Our round top windows elevate curb appeal and enhance traditional homes. Energy-efficient round top windows offer unique style. Choose Paragon Exterior for professional round top windows in PA, NJ, and DE.',
+    openGraph: {
+        title: 'Round Top Windows | Professional Round Top Window Installation',
+        description: 'Round top windows add distinctive arches and architectural interest. Our round top windows elevate curb appeal and enhance traditional homes. Energy-efficient round top windows offer unique style. Choose Paragon Exterior for professional round top windows in PA, NJ, and DE.',
+        type: 'website',
+        images: ['/images/windows/round-top/round-top-hero.webp'],
+    },
+};
+
+export default function RoundTopWindowsPage() {
+    return (
+        <div className="min-h-screen">
+            <Hero
+                mainText="Round Top Windows"
+                subText="Round top windows add a graceful arch that enhances curb appeal and architectural charm. Paragon Exterior installs round top windows for homeowners in Pennsylvania, New Jersey, and Delaware."
+                imgSrc="/images/windows/round-top/round-top-hero.webp"
+                imgAlt="Professional round top window installation by Paragon Exterior"
+            />
+            <InfoSection
+                imgSrc="/images/windows/round-top/round-top-1.webp"
+                imgAlt="Round top windows professionally installed on home"
+                titleAs="h1"
+                title="Round Top Windows for Your Home"
+                mainContent="Round top windows feature an arched design that brings distinctive character to traditional and colonial-style homes. They can be fixed or operable and often serve as decorative accents above standard windows or doors."
+                bottomContent="Our craftsmen are experienced in shaping and installing custom round top windows throughout the Greater Philadelphia area. We ensure each arch fits perfectly and complements your home's design."
+                imagePosition="right"
+            />
+            <Row
+                title="Benefits of Round Top Windows"
+                description="The curved top creates visual interest and allows more natural light into your home. Round top windows are a striking detail that increases curb appeal and property value."
+                imageSrc="/images/windows/round-top/round-top-2.webp"
+            />
+            <Row
+                title="Ideal Uses for Round Top Windows"
+                description="Use round top windows above entryways, in gable ends, or as unique focal points in living spaces. They pair beautifully with other window styles."
+                imageSrc="/images/windows/round-top/round-top-3.webp"
+                reverse
+                className="pt-12 lg:pt-24"
+            />
+            <Row
+                title="Professional Round Top Window Installation"
+                description="Arched windows require precise measurements and framing techniques. Paragon Exterior ensures smooth curves, secure seals, and lasting performance for every round top window."
+                imageSrc="/images/windows/round-top/round-top-4.webp"
+            />
+            <WhyParagonRoundTopWindows
+                title="Why Choose Paragon Exterior for Round Top Windows?"
+                titleAs="h2"
+            />
+            <div className="py-12">
+                <GetEstimate />
+            </div>
+        </div>
+    );
+}

--- a/src/components/WhyParagon.tsx
+++ b/src/components/WhyParagon.tsx
@@ -364,6 +364,174 @@ const serviceReasons = {
         },
     ],
 
+    'casement-windows': [
+        {
+            icon: FaHome,
+            title: "Casement Window Specialists",
+            description: "Our team expertly installs and services casement windows across Pennsylvania, New Jersey, and Delaware. We understand side-hinged hardware and weatherproofing requirements to ensure smooth operation and tight seals.",
+            keywordPhrase: "casement windows"
+        },
+        {
+            icon: FaTools,
+            title: "Expert Casement Installation",
+            description: "Precise casement window installation is crucial for full ventilation and easy operation. We ensure frames are plumb, hardware properly aligned, and energy-efficient glazing optimized for local climates.",
+            keywordPhrase: "professional casement installation"
+        },
+        {
+            icon: FaShieldAlt,
+            title: "Quality Casement Performance",
+            description: "With quality casement windows installed by Paragon Exterior, homeowners enjoy long-term performance, energy efficiency, and unobstructed views. Our meticulous workmanship ensures lasting reliability.",
+            keywordPhrase: "quality casement windows"
+        },
+    ],
+
+    'double-hung-windows': [
+        {
+            icon: FaHome,
+            title: "Double Hung Window Specialists",
+            description: "We work with traditional double hung window systems in historic and modern homes throughout PA, NJ, and DE. Our experts address balance systems and sash fit for smooth operation.",
+            keywordPhrase: "double hung windows"
+        },
+        {
+            icon: FaTools,
+            title: "Expert Double Hung Installation",
+            description: "Professional double hung installation prevents air leaks around moving sashes and allows for easy tilt-in cleaning. Proper counterweights and weatherstripping ensure lasting performance.",
+            keywordPhrase: "professional double hung installation"
+        },
+        {
+            icon: FaShieldAlt,
+            title: "Quality Double Hung Performance",
+            description: "Quality double hung windows installed by our team provide classic style with modern efficiency. We focus on durable components that hold up to daily use and seasonal weather.",
+            keywordPhrase: "quality double hung windows"
+        },
+    ],
+
+    'awning-windows': [
+        {
+            icon: FaHome,
+            title: "Awning Window Specialists",
+            description: "Awning windows require careful top-hinge alignment and weatherproofing. Our installers handle awning windows in bathrooms, basements, and hard-to-reach areas across Greater Philadelphia.",
+            keywordPhrase: "awning windows"
+        },
+        {
+            icon: FaTools,
+            title: "Expert Awning Installation",
+            description: "Professional awning window installation ensures smooth crank operation and tight seals that keep rain out even when open. We pay attention to hardware durability and framing.",
+            keywordPhrase: "professional awning installation"
+        },
+        {
+            icon: FaShieldAlt,
+            title: "Quality Awning Performance",
+            description: "Quality awning windows from Paragon Exterior provide ventilation and privacy with minimal maintenance. Our expertise results in long-term performance and energy savings.",
+            keywordPhrase: "quality awning windows"
+        },
+    ],
+
+    'glider-windows': [
+        {
+            icon: FaHome,
+            title: "Glider Window Specialists",
+            description: "Glider windows slide horizontally on tracks that must be level and debris-free. We install glider windows with precise track alignment for homes across PA, NJ, and DE.",
+            keywordPhrase: "glider windows"
+        },
+        {
+            icon: FaTools,
+            title: "Expert Glider Installation",
+            description: "Professional glider window installation ensures effortless operation and prevents drafts. We focus on smooth rollers, secure locking mechanisms, and proper weatherstripping.",
+            keywordPhrase: "professional glider installation"
+        },
+        {
+            icon: FaShieldAlt,
+            title: "Quality Glider Performance",
+            description: "Quality glider windows add modern style and easy functionality. With Paragon Exterior's skilled installation, you enjoy reliable performance and large viewing areas.",
+            keywordPhrase: "quality glider windows"
+        },
+    ],
+
+    'bay-windows': [
+        {
+            icon: FaHome,
+            title: "Bay Window Specialists",
+            description: "Bay window projects require structural insight and precise framing. Our specialists create beautiful bay window assemblies that add space and light to homes in Pennsylvania, New Jersey, and Delaware.",
+            keywordPhrase: "bay windows"
+        },
+        {
+            icon: FaTools,
+            title: "Expert Bay Installation",
+            description: "Expert bay window installation ensures proper support, airtight connections, and weatherproofing across multiple angles. We coordinate trim and roofing details for a seamless look.",
+            keywordPhrase: "professional bay installation"
+        },
+        {
+            icon: FaShieldAlt,
+            title: "Quality Bay Performance",
+            description: "Quality bay windows installed by Paragon Exterior provide panoramic views and expanded interiors for decades. Our focus on engineering and craftsmanship delivers lasting value.",
+            keywordPhrase: "quality bay windows"
+        },
+    ],
+
+    'bow-windows': [
+        {
+            icon: FaHome,
+            title: "Bow Window Specialists",
+            description: "Bow windows curve gracefully outward, demanding careful custom framing and support. Our team designs and installs bow windows across the tri-state area with meticulous attention to detail.",
+            keywordPhrase: "bow windows"
+        },
+        {
+            icon: FaTools,
+            title: "Expert Bow Installation",
+            description: "Professional bow window installation requires precise alignment of multiple units to create a smooth curve and reliable performance. We handle the structural engineering and waterproofing.",
+            keywordPhrase: "professional bow installation"
+        },
+        {
+            icon: FaShieldAlt,
+            title: "Quality Bow Performance",
+            description: "Quality bow windows from Paragon Exterior offer elegant aesthetics and expansive views. Our expert installation ensures durable performance and minimal maintenance.",
+            keywordPhrase: "quality bow windows"
+        },
+    ],
+
+    'picture-windows': [
+        {
+            icon: FaHome,
+            title: "Picture Window Specialists",
+            description: "Picture windows are fixed units that showcase uninterrupted views. We install energy-efficient picture windows across PA, NJ, and DE with expert sealing and framing.",
+            keywordPhrase: "picture windows"
+        },
+        {
+            icon: FaTools,
+            title: "Expert Picture Installation",
+            description: "Proper picture window installation maximizes thermal efficiency and prevents water infiltration. We use advanced glazing and airtight construction for lasting performance.",
+            keywordPhrase: "professional picture installation"
+        },
+        {
+            icon: FaShieldAlt,
+            title: "Quality Picture Performance",
+            description: "Quality picture windows installed by Paragon Exterior deliver scenic views and energy savings with minimal upkeep. Our craftsmanship ensures your investment lasts.",
+            keywordPhrase: "quality picture windows"
+        },
+    ],
+
+    'round-top-windows': [
+        {
+            icon: FaHome,
+            title: "Round Top Window Specialists",
+            description: "Round top windows add architectural interest and require precise arched framing. Our specialists craft custom round top solutions for homes throughout Pennsylvania, New Jersey, and Delaware.",
+            keywordPhrase: "round top windows"
+        },
+        {
+            icon: FaTools,
+            title: "Expert Round Top Installation",
+            description: "Professional round top window installation ensures curved units fit perfectly and maintain structural integrity. We carefully seal and secure each arch for reliable performance.",
+            keywordPhrase: "professional round top installation"
+        },
+        {
+            icon: FaShieldAlt,
+            title: "Quality Round Top Performance",
+            description: "Quality round top windows from Paragon Exterior elevate curb appeal and preserve historical charm. Our expert installation guarantees longevity and energy efficiency.",
+            keywordPhrase: "quality round top windows"
+        },
+    ],
+
 };
 
 export default function WhyParagon({
@@ -522,5 +690,29 @@ export const WhyParagonWindowReplacement = (props: Omit<WhyParagonProps, 'servic
     <WhyParagon {...props} service="window-replacement" />;
 
 
-export const WhyParagonWindowInstallation = (props: Omit<WhyParagonProps, 'service'>) => 
+export const WhyParagonWindowInstallation = (props: Omit<WhyParagonProps, 'service'>) =>
     <WhyParagon {...props} service="window-installation" />;
+
+export const WhyParagonCasementWindows = (props: Omit<WhyParagonProps, 'service'>) =>
+    <WhyParagon {...props} service="casement-windows" />;
+
+export const WhyParagonDoubleHungWindows = (props: Omit<WhyParagonProps, 'service'>) =>
+    <WhyParagon {...props} service="double-hung-windows" />;
+
+export const WhyParagonAwningWindows = (props: Omit<WhyParagonProps, 'service'>) =>
+    <WhyParagon {...props} service="awning-windows" />;
+
+export const WhyParagonGliderWindows = (props: Omit<WhyParagonProps, 'service'>) =>
+    <WhyParagon {...props} service="glider-windows" />;
+
+export const WhyParagonBayWindows = (props: Omit<WhyParagonProps, 'service'>) =>
+    <WhyParagon {...props} service="bay-windows" />;
+
+export const WhyParagonBowWindows = (props: Omit<WhyParagonProps, 'service'>) =>
+    <WhyParagon {...props} service="bow-windows" />;
+
+export const WhyParagonPictureWindows = (props: Omit<WhyParagonProps, 'service'>) =>
+    <WhyParagon {...props} service="picture-windows" />;
+
+export const WhyParagonRoundTopWindows = (props: Omit<WhyParagonProps, 'service'>) =>
+    <WhyParagon {...props} service="round-top-windows" />;


### PR DESCRIPTION
## Summary
- add service reasons for window specific pages and export helper functions
- create casement, double-hung, awning, glider, bay, bow, picture, and round-top pages under `src/app/windows`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c226cce6c83218fd32f823b785ab5